### PR TITLE
Use eq to compare symbols

### DIFF
--- a/puml-mode.el
+++ b/puml-mode.el
@@ -126,8 +126,7 @@
 
 (defun puml-is-image-output-p ()
   "Return true if the diagram output format is an image, false if it's text based."
-  (not (equalp 'utxt
-               (puml-output-type))))
+  (not (eq 'utxt (puml-output-type))))
 
 (defun puml-output-type-opt ()
   "Create the flag to pass to PlantUML to produce the selected output format."


### PR DESCRIPTION
The equalp function is defined in the 'cl' library, which is not loaded
by default. So I was getting the error

    error in process sentinel: not: Symbol's function definition is void:
    equalp

I replaced it with eq as it is comparing symbols.