### PR TITLE
Customizable output type

### DIFF
--- a/puml-mode.el
+++ b/puml-mode.el
@@ -124,9 +124,11 @@
 (defconst puml-preview-buffer "*PUML Preview*")
 
 (defvar puml-output-type
-  (cond ((image-type-available-p 'svg) "svg")
-        ((image-type-available-p 'png) "png")
-        (t "utxt"))
+  (if (not (display-images-p))
+      "utxt"
+    (cond ((image-type-available-p 'svg) "svg")
+	  ((image-type-available-p 'png) "png")
+	  (t "utxt")))
   "Specify the desired output type to use for generated diagrams.")
 
 (defun puml-read-output-type ()


### PR DESCRIPTION
Change `puml-output-type` to be a variable, so the user can customize it.

It can also be set by calling `puml-set-output-type` interactively for each buffer individually.

In addition of that, it fixes the output for the utxt type.