### PR TITLE
Add comment symbol

### DIFF
--- a/puml-mode.el
+++ b/puml-mode.el
@@ -281,6 +281,7 @@ default output type for new buffers."
 Shortcuts             Command Name
 \\[puml-complete-symbol]      `puml-complete-symbol'"
   (make-local-variable 'puml-output-type)
+  (set (make-local-variable 'comment-start) "' ")
   (setq font-lock-defaults '((puml-font-lock-keywords) nil t)))
 
 (provide 'puml-mode)


### PR DESCRIPTION
This adds `'` as the default comment symbol for puml-mode, so `comment-dwim` will work.