### PR TITLE
allow puml-preview to open in other window, frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,11 @@ Default key bindings
 
 The following shortcuts are enabled by default:
 
-    C-c C-c  renders a PlantUML diagram from the current buffer in the best supported format
+    C-c C-c  puml-preview: renders a PlantUML diagram from the current buffer in the best supported format
+    
+    C-u C-c C-c  puml-preview in other window
+    
+    C-u C-u C-c C-c puml-preview in other frame
 
 Troubleshooting
 ===============

--- a/puml-mode.el
+++ b/puml-mode.el
@@ -189,9 +189,9 @@ default output type for new buffers."
   "Create the flag to pass to PlantUML to produce the selected output format."
   (concat "-t" puml-output-type))
 
-(defun puml-preview ()
+(defun puml-preview (prefix)
   "Preview diagram."
-  (interactive)
+  (interactive "p")
   (let ((b (get-buffer puml-preview-buffer)))
     (when b
       (kill-buffer b)))
@@ -212,7 +212,12 @@ default output type for new buffers."
                             (lambda (ps event)
                               (unless (equal event "finished\n")
                                 (error "PUML Preview failed: %s" event))
-                              (switch-to-buffer puml-preview-buffer)
+                              (cond
+                               ((= prefix 16)
+                                (switch-to-buffer-other-frame puml-preview-buffer))
+                               ((= prefix 4)
+                                (switch-to-buffer-other-window puml-preview-buffer))
+                               (t (switch-to-buffer puml-preview-buffer)))
                               (when imagep
                                 (image-mode)
                                 (set-buffer-multibyte t)))))))


### PR DESCRIPTION
I added a feature to allow showing the puml-preview in a different window and frame.

This works as follows:

    C-c C-c -- puml-preview in the same window
    C-u C-c C-c -- puml-preview in a different window
    C-u C-u C-c C-c -- puml-preview in a different frame